### PR TITLE
Autofix collection builtins when called to use literals instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@
   - Calls to `dict()` with keyword arguments are converted to dict literal
     syntax, e.g. `dict(x=1)` becomes `{"x": 1}`
 
+> NOTE
+> The new transformation can be unsafe in certain rare cases. Specifically, the
+> builtin names can be rebound to user-defined callables. This would
+> potentially result in the fixer converting a meaningful call to these
+> user-defined values.
+>
+> This can only occur if you rebind very well-known names,
+> e.g., `def dict(...): ...`
+>
+> Because there are no well-known cases in which such name shadowing is
+> important or essential, this is not considered a bug. Just don't shadow
+> these builtin names like that.
+> You can always disable fixing with comments for certain lines.
+
 # 0.6.1
 
 - Enable autofixing of some concatenated strings which combine f-strings with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Unreleased
 <!-- changelog-unreleased-marker -->
 
+- New autofixing behavior has been added, inspired by the rules of
+  flake8-comprehensions. The following autofixing behaviors are newly
+  added:
+  - Calls to `dict()`, `list()`, and `tuple()` with no arguments are replaced
+    with the relevant literals, `{}`, `[]`, and `()`
+  - Calls to `set()` and `list()` on generator expressions are converted to set
+    and list comprehensions
+  - Calls to `dict()` with keyword arguments are converted to dict literal
+    syntax, e.g. `dict(x=1)` becomes `{"x": 1}`
+
 # 0.6.1
 
 - Enable autofixing of some concatenated strings which combine f-strings with

--- a/src/slyp/driver.py
+++ b/src/slyp/driver.py
@@ -19,7 +19,7 @@ from slyp.hashable_file import HashableFile
 from slyp.result import Message, Result
 
 DEFAULT_DISABLED_CODES: set[str] = {"W201", "W202", "W203"}
-CONTRACT_VERSION: str = "1.4"
+CONTRACT_VERSION: str = "1.5"
 
 
 def driver_main(args: argparse.Namespace) -> bool:

--- a/src/slyp/fixer/transformer.py
+++ b/src/slyp/fixer/transformer.py
@@ -323,6 +323,9 @@ class SlypTransformer(libcst.CSTTransformer):
                 elements=[_convert_dict_element(arg) for arg in updated_node.args],
                 lpar=updated_node.lpar,
                 rpar=updated_node.rpar,
+                lbrace=libcst.LeftCurlyBrace(
+                    whitespace_after=updated_node.whitespace_before_args
+                ),
             )
             if not original_node.lpar:
                 return dict_node
@@ -937,5 +940,9 @@ def _convert_dict_element(arg: libcst.Arg) -> libcst.BaseDictElement:
         return libcst.DictElement(
             key=libcst.SimpleString(value=f'"{arg.keyword.value}"'),
             value=arg.value,
+            comma=arg.comma,
         )
-    return libcst.StarredDictElement(value=arg.value)
+    return libcst.StarredDictElement(
+        value=arg.value,
+        comma=arg.comma,
+    )

--- a/src/slyp/fixer/transformer.py
+++ b/src/slyp/fixer/transformer.py
@@ -319,11 +319,14 @@ class SlypTransformer(libcst.CSTTransformer):
                 ],
             ),
         ):
-            updated_node = libcst.Dict(
-                elements=[_convert_dict_element(arg) for arg in original_node.args],
-                lpar=original_node.lpar,
-                rpar=original_node.rpar,
+            dict_node = libcst.Dict(
+                elements=[_convert_dict_element(arg) for arg in updated_node.args],
+                lpar=updated_node.lpar,
+                rpar=updated_node.rpar,
             )
+            if not original_node.lpar:
+                return dict_node
+            return self.modify_parenthesized_node(original_node, dict_node)
 
         if not original_node.lpar:
             return updated_node

--- a/src/slyp/fixer/transformer.py
+++ b/src/slyp/fixer/transformer.py
@@ -345,7 +345,7 @@ class SlypTransformer(libcst.CSTTransformer):
             ),
         ):
             funcname = original_node.func.value  # type: ignore[attr-defined]
-            literal_node: libcst.Set | libcst.List
+            literal_node: libcst.Tuple | libcst.List
             if funcname == "tuple":
                 lpar = updated_node.lpar if updated_node.lpar else [libcst.LeftParen()]
                 rpar = updated_node.rpar if updated_node.rpar else [libcst.RightParen()]

--- a/tests/fixers/test_collection_builtin_call.py
+++ b/tests/fixers/test_collection_builtin_call.py
@@ -99,3 +99,41 @@ def test_dict_call_fixer_preserves_the_simplest_whitespace(fix_text):
         }
         """
     )
+
+
+def test_set_fixer_converts_call_of_generator(fix_text):
+    new_text, _ = fix_text(
+        """\
+        a = set(x for x in y())
+        """
+    )
+    assert new_text == textwrap.dedent(
+        """\
+        a = {x for x in y()}
+        """
+    )
+
+
+def test_list_fixer_converts_call_of_generator(fix_text):
+    new_text, _ = fix_text(
+        """\
+        a = list(x for x in y())
+        """
+    )
+    assert new_text == textwrap.dedent(
+        """\
+        a = [x for x in y()]
+        """
+    )
+
+
+def test_generator_comp_fixer_requires_exactly_one_arg(fix_text):
+    # these usages are syntactically valid but semantically incorrect
+    # however, the fixer should ignore them as "not my problem"
+    fix_text(
+        """\
+        a = set((x for x in y()), True)
+        b = list((x for x in y()), True)
+        """,
+        expect_changes=False,
+    )

--- a/tests/fixers/test_collection_builtin_call.py
+++ b/tests/fixers/test_collection_builtin_call.py
@@ -1,0 +1,101 @@
+import textwrap
+
+
+def test_dict_call_fixer_converts_empty_call_to_empty_literal(fix_text):
+    new_text, _ = fix_text(
+        """\
+        x = dict()
+        """
+    )
+    assert new_text == textwrap.dedent(
+        """\
+        x = {}
+        """
+    )
+
+
+def test_dict_call_fixer_converts_kwargs_to_quoted_keys(fix_text):
+    new_text, _ = fix_text(
+        """\
+        a = dict(x=1, y="foo", z_arg={})
+        """
+    )
+    assert new_text == textwrap.dedent(
+        """\
+        a = {"x": 1, "y": "foo", "z_arg": {}}
+        """
+    )
+
+
+def test_dict_call_fixer_preserves_double_star_expansion(fix_text):
+    new_text, _ = fix_text(
+        """\
+        a = dict(x=1, **kwargs)
+        """
+    )
+    assert new_text == textwrap.dedent(
+        """\
+        a = {"x": 1, **kwargs}
+        """
+    )
+
+
+def test_dict_call_fixer_handles_multi_doublestar(fix_text):
+    new_text, _ = fix_text(
+        """\
+        a = dict(x=1, **kwargs, **kwargs2)
+        """
+    )
+    assert new_text == textwrap.dedent(
+        """\
+        a = {"x": 1, **kwargs, **kwargs2}
+        """
+    )
+
+
+def test_dict_call_fixer_does_not_munge_positional_arg(fix_text):
+    fix_text(
+        """\
+        a = dict([("x", 1)])
+        b = dict([("x", 1)], y=2)
+        c = dict(some_func(), y=2)
+        d = dict(some_func(), **other)
+        e = dict(some_name, **other)
+        f = dict(some_name)
+        """,
+        expect_changes=False,
+    )
+
+
+def test_dict_call_fixer_handles_nested_calls(fix_text):
+    new_text, _ = fix_text(
+        """\
+        a = dict(x=dict(y=2))
+        """
+    )
+    assert new_text == textwrap.dedent(
+        """\
+        a = {"x": {"y": 2}}
+        """
+    )
+
+
+def test_dict_call_fixer_preserves_the_simplest_whitespace(fix_text):
+    new_text, _ = fix_text(
+        """\
+        a = dict(
+            x=dict(
+                y=2,
+            ),
+        )
+        """
+    )
+    assert new_text == textwrap.dedent(
+        """\
+        a = {
+            "x": {
+                "y": 2,
+            },
+        }
+        """
+    )

--- a/tests/fixers/test_collection_builtin_call.py
+++ b/tests/fixers/test_collection_builtin_call.py
@@ -1,17 +1,21 @@
 import textwrap
 
+import pytest
 
-def test_dict_call_fixer_converts_empty_call_to_empty_literal(fix_text):
-    new_text, _ = fix_text(
-        """\
-        x = dict()
-        """
-    )
-    assert new_text == textwrap.dedent(
-        """\
-        x = {}
-        """
-    )
+
+@pytest.mark.parametrize(
+    "original_text, fixed_text",
+    [
+        ("dict()", "{}"),
+        ("list()", "[]"),
+        ("tuple()", "()"),
+    ],
+)
+def test_builtin_call_fixer_converts_empty_call_to_empty_literal(
+    fix_text, original_text, fixed_text
+):
+    new_text, _ = fix_text(f"x = {original_text}")
+    assert new_text == f"x = {fixed_text}"
 
 
 def test_dict_call_fixer_converts_kwargs_to_quoted_keys(fix_text):

--- a/tests/fixers/test_unnecessary_parens.py
+++ b/tests/fixers/test_unnecessary_parens.py
@@ -212,14 +212,14 @@ def test_lambdas_and_yields_with_many_parens(fix_text):
 def test_generator_expressions(fix_text):
     new_text, _ = fix_text(
         """\
-        a = list(x for x in foo())
+        a = foo(x for x in bar())
         b = foo((x for x in bar()), baz())
         c = foo(((x for x in bar())), baz())
         """
     )
     assert new_text == textwrap.dedent(
         """\
-        a = list(x for x in foo())
+        a = foo(x for x in bar())
         b = foo((x for x in bar()), baz())
         c = foo((x for x in bar()), baz())
         """


### PR DESCRIPTION
- Automatically convert `dict(x=1)` to `{"x": 1}`
- Fix bug with dict transform on nested dicts
- Add tests for dict call transformer
- Add autofixing for set()/list() of generator
- Fix type errors in builtin call fixers
- Autofix tuple and list calls with no args
- Update CONTRACT_VERSION and changelog
