### PR TITLE
Improve handling of dict whitespace when fixing

### DIFF
--- a/src/slyp/fixer/transformer.py
+++ b/src/slyp/fixer/transformer.py
@@ -331,6 +331,9 @@ class SlypTransformer(libcst.CSTTransformer):
                 lbrace=libcst.LeftCurlyBrace(
                     whitespace_after=updated_node.whitespace_before_args
                 ),
+                rbrace=libcst.RightCurlyBrace(
+                    whitespace_before=_last_arg_whitespace(updated_node)
+                ),
             )
             if not original_node.lpar:
                 return dict_node
@@ -1010,5 +1013,10 @@ def _convert_dict_element(arg: libcst.Arg) -> libcst.BaseDictElement:
         )
     return libcst.StarredDictElement(
         value=arg.value,
-        comma=arg.comma,
     )
+
+
+def _last_arg_whitespace(node: libcst.Call) -> libcst.BaseParenthesizableWhitespace:
+    if not node.args:
+        return libcst.SimpleWhitespace("")
+    return node.args[-1].whitespace_after_arg

--- a/src/slyp/fixer/transformer.py
+++ b/src/slyp/fixer/transformer.py
@@ -1013,6 +1013,7 @@ def _convert_dict_element(arg: libcst.Arg) -> libcst.BaseDictElement:
         )
     return libcst.StarredDictElement(
         value=arg.value,
+        comma=arg.comma,
     )
 
 

--- a/tests/fixers/test_collection_builtin_call.py
+++ b/tests/fixers/test_collection_builtin_call.py
@@ -85,7 +85,9 @@ def test_dict_call_fixer_handles_nested_calls(fix_text):
 
 
 def test_dict_call_fixer_preserves_the_simplest_whitespace(fix_text):
-    # check a case with and without a trailing comma
+    # trailing comma whitespace + leading whitespace is the simple case
+    # because the trailing comma carries the whitespace info, it's easy to
+    # preserve by just keeping the comma intact
     new_text, _ = fix_text(
         """\
         a = dict(
@@ -93,10 +95,7 @@ def test_dict_call_fixer_preserves_the_simplest_whitespace(fix_text):
                 y=2,
             ),
             z=dict(
-                snork="hi"
-            ),
-            p=dict(
-
+                **p,
             )
         )
         """
@@ -108,11 +107,46 @@ def test_dict_call_fixer_preserves_the_simplest_whitespace(fix_text):
                 "y": 2,
             },
             "z": {
-                "snork": "hi"
+                **p,
+            }
+        }
+        """
+    )
+
+
+def test_dict_call_fixer_preserves_intricate_whitespace(fix_text):
+    # no trailing comma, or empty block are more intricate cases
+    # we need to find the whitespace which is attached to the last arg
+    # and reattach it to the rbrace
+    new_text, _ = fix_text(
+        """\
+        a = dict(
+            x=dict(
+                    y="hi"
+            ),
+            z=dict(
+
+            ),
+            p=dict(
+
+                **q
+        )
+        )
+        """
+    )
+    assert new_text == textwrap.dedent(
+        """\
+        a = {
+            "x": {
+                    "y": "hi"
+            },
+            "z": {
+
             },
             "p": {
 
-            }
+                **q
+        }
         }
         """
     )

--- a/tests/fixers/test_collection_builtin_call.py
+++ b/tests/fixers/test_collection_builtin_call.py
@@ -85,12 +85,19 @@ def test_dict_call_fixer_handles_nested_calls(fix_text):
 
 
 def test_dict_call_fixer_preserves_the_simplest_whitespace(fix_text):
+    # check a case with and without a trailing comma
     new_text, _ = fix_text(
         """\
         a = dict(
             x=dict(
                 y=2,
             ),
+            z=dict(
+                snork="hi"
+            ),
+            p=dict(
+
+            )
         )
         """
     )
@@ -100,6 +107,12 @@ def test_dict_call_fixer_preserves_the_simplest_whitespace(fix_text):
             "x": {
                 "y": 2,
             },
+            "z": {
+                "snork": "hi"
+            },
+            "p": {
+
+            }
         }
         """
     )


### PR DESCRIPTION
`dict()` calls can have trailing whitespace attached to the last
argument in the args list. In this case, keep that whitespace and
attach it to the right curly brace on the fixed dict literal.
