### PR TITLE
Add fixing behavior for `set(list(X))`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@
   flake8-comprehensions. The following autofixing behaviors are newly
   added:
   - Calls to `dict()`, `list()`, and `tuple()` with no arguments are replaced
-    with the relevant literals, `{}`, `[]`, and `()`
+    with the relevant literals, `{}`, `[]`, and `()`.
   - Calls to `set()` and `list()` on generator expressions are converted to set
-    and list comprehensions
+    and list comprehensions.
   - Calls to `dict()` with keyword arguments are converted to dict literal
-    syntax, e.g. `dict(x=1)` becomes `{"x": 1}`
+    syntax.
+    e.g., `dict(x=1)` becomes `{"x": 1}`
+  - Calls to `set()` and `frozenset()` whose argument is a builtin which
+    produces an iterable are unwrapped.
+    e.g., `set(list(foo()))` becomes `set(foo())`
 
 > NOTE
 > The new transformation can be unsafe in certain rare cases. Specifically, the

--- a/src/slyp/fixer/transformer.py
+++ b/src/slyp/fixer/transformer.py
@@ -336,13 +336,14 @@ class SlypTransformer(libcst.CSTTransformer):
         ):
             return updated_node
 
-        if original_node.func.value == "dict":
+        func_name: str = original_node.func.value  # type: ignore[attr-defined]
+        if func_name == "dict":
             return self._fix_dict_call(original_node, updated_node)
-        elif original_node.func.value == "list":
+        elif func_name == "list":
             return self._fix_list_call(original_node, updated_node)
-        elif original_node.func.value == "tuple":
+        elif func_name == "tuple":
             return self._fix_tuple_call(original_node, updated_node)
-        elif original_node.func.value in ("set", "frozenset"):
+        elif func_name in ("set", "frozenset"):
             return self._fix_set_call(original_node, updated_node)
         else:
             return updated_node
@@ -455,7 +456,7 @@ class SlypTransformer(libcst.CSTTransformer):
                 ],
             ),
         ):
-            arg0: libcst.Call = updated_node.args[0].value  # type:ignore[attr-defined]
+            arg0: libcst.Call = updated_node.args[0].value  # type: ignore[assignment]
             if not arg0.args:
                 # if we are seeing no args, like `set(set())`, that's just `set()`
                 updated_node = updated_node.with_changes(args=[])

--- a/tests/fixers/test_collection_builtin_call.py
+++ b/tests/fixers/test_collection_builtin_call.py
@@ -188,3 +188,42 @@ def test_generator_comp_fixer_requires_exactly_one_arg(fix_text):
         """,
         expect_changes=False,
     )
+
+
+@pytest.mark.parametrize("set_variant", ("set", "frozenset"))
+@pytest.mark.parametrize(
+    "expression, unwrapped",
+    (
+        ("set(foo)", "foo"),
+        ("list(foo)", "foo"),
+        ("sorted(foo)", "foo"),
+        ("sorted(foo, reversed=True)", "foo"),
+        ("reversed(foo)", "foo"),
+        ("tuple(foo)", "foo"),
+        ("set(tuple(foo))", "foo"),
+        ("set()", ""),
+        ("frozenset()", ""),
+    ),
+)
+def test_iterable_call_under_set_call_is_unwrapped(
+    fix_text, set_variant, expression, unwrapped
+):
+    new_text, _ = fix_text(f"{set_variant}({expression})")
+    assert new_text == f"{set_variant}({unwrapped})"
+
+
+def test_nested_iterable_calls_under_set_work(fix_text):
+    # this is a regression test for a bug in which testing on the `original_node` led
+    # to an incorrect conclusion being drawn about the `updated_node`
+    new_text, _ = fix_text(
+        """\
+        set(tuple())
+        set(list())
+        """
+    )
+    assert new_text == textwrap.dedent(
+        """\
+        set(())
+        set([])
+        """
+    )


### PR DESCRIPTION
As described in the changelog, this is a new fixer behavior for
`set()` calls.
