### PR TITLE
Add unwrapping `list()` call fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   - Calls to `set()` and `frozenset()` whose argument is a builtin which
     produces an iterable are unwrapped.
     e.g., `set(list(foo()))` becomes `set(foo())`
+  - Calls to `list()` whose argument is a builtin which produces a `list` are
+    unwrapped.
+    e.g., `list(sorted(foo))` becomes `sorted(foo)`
 
 > NOTE
 > The new transformation can be unsafe in certain rare cases. Specifically, the

--- a/tests/fixers/test_collection_builtin_call.py
+++ b/tests/fixers/test_collection_builtin_call.py
@@ -237,3 +237,32 @@ def test_nested_iterable_calls_under_set_work(fix_text):
         set()
         """
     )
+
+
+@pytest.mark.parametrize(
+    "expression, unwrapped",
+    (
+        ("list(foo)", "foo"),
+        ("list(list(foo))", "foo"),
+        ("tuple(foo)", "foo"),
+        ("tuple(list(tuple(foo)))", "foo"),
+    ),
+)
+def test_order_preserving_iterable_call_under_list_call_is_unwrapped(
+    fix_text, expression, unwrapped
+):
+    new_text, _ = fix_text(f"list({expression})")
+    assert new_text == f"list({unwrapped})"
+
+
+@pytest.mark.parametrize(
+    "expression",
+    (
+        "reversed(foo)",
+        "sorted(foo)",
+        "sorted(foo, key=lambda x: x[0])",
+    ),
+)
+def test_reordering_list_call_under_list_call_bubbles_up(fix_text, expression):
+    new_text, _ = fix_text(f"list({expression})")
+    assert new_text == expression


### PR DESCRIPTION
This is similar to the `set()` unwrapping behavior, but specialized for `list()`.
