### PR TITLE
Fix __init__ signatures to always return None

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -10,6 +10,8 @@ Unreleased
   fixing. This applies to certain cases in which an ``if`` was not followed by
   a space, as in ``if(x): pass``. These cases may now require two runs to
   converge.
+- Add fixer behavior to add a ``-> None`` return type annotation to
+  ``__init__`` methods which have no return type annotation.
 
 0.7.1
 -----

--- a/docs/fixer_rules.rst
+++ b/docs/fixer_rules.rst
@@ -103,3 +103,29 @@ if possible.
     +x = "foo bar"
     -y = f"{item1} " f"{item2}"
     +y = f"{item1} {item2}"
+
+
+Always annotate ``__init__` with ``-> None``
+--------------------------------------------
+
+.. note::
+
+    An unannotated initializer with no args is treated by type checkers as an
+    unannotated function. i.e. ``def __init__(self): ...`` is not annotated.
+    But adding a ``-> None`` annotation makes it into an annotated function,
+    and can change checker behaviors.
+
+    By contrast, ``def __init__(self, x: int): ...`` is treated as annotated,
+    and the ``-> None`` is not needed to mark it as annotated.
+
+    This results in discrepancies between code with an without the return type
+    annotation.
+
+When defining initializers, always declare the return type as ``None``.
+
+.. code-block:: diff
+
+     class A:
+    -    def __init__(self):
+    +    def __init__(self) -> None:
+             self.x = 1

--- a/src/slyp/fixer/transformer.py
+++ b/src/slyp/fixer/transformer.py
@@ -5,6 +5,11 @@ import typing as t
 import libcst
 import libcst.matchers
 
+# an __init__ definition missing the return type annotation
+MISSING_RETURN_ANNOTATION_INIT_MATCHER = libcst.matchers.FunctionDef(
+    name=libcst.matchers.Name(value="__init__"), returns=None
+)
+
 # SimpleWhitespace defines whitespace as seen between tokens in most contexts
 # it can contain newlines *if* there is a preceding backslash escape
 SIMPLE_WHITESPACE_NO_NEWLINE_MATCHER = libcst.matchers.SimpleWhitespace(
@@ -1116,6 +1121,17 @@ class SlypTransformer(libcst.CSTTransformer):
                     )
                 )
 
+        return updated_node
+
+    def leave_FunctionDef(
+        self, original_node: libcst.FunctionDef, updated_node: libcst.FunctionDef
+    ) -> libcst.FunctionDef:
+        if libcst.matchers.matches(
+            original_node, MISSING_RETURN_ANNOTATION_INIT_MATCHER
+        ):
+            updated_node = updated_node.with_changes(
+                returns=libcst.Annotation(annotation=libcst.Name("None"))
+            )
         return updated_node
 
     def leave_ImportFrom(

--- a/tests/fixers/test_fix_special_functions.py
+++ b/tests/fixers/test_fix_special_functions.py
@@ -1,0 +1,52 @@
+import textwrap
+
+
+def test_unannotated_init_gets_return_none_added(fix_text):
+    new_text, _ = fix_text(
+        """\
+        class A:
+            def __init__(self): ...
+        """
+    )
+    assert new_text == textwrap.dedent(
+        """\
+        class A:
+            def __init__(self) -> None: ...
+        """
+    )
+
+
+def test_annotated_init_sees_no_change(fix_text):
+    fix_text(
+        """\
+        class A:
+            def __init__(self) -> None: ...
+        """,
+        expect_changes=False,
+    )
+
+
+def test_badly_annotated_init_sees_no_change(fix_text):
+    # this annotation is fundamentally *wrong*, but it should be ignored by the fixer
+    fix_text(
+        """\
+        class A:
+            def __init__(self) -> A: ...
+        """,
+        expect_changes=False,
+    )
+
+
+def test_mixed_arg_annotations_dont_change_init_type(fix_text):
+    new_text, _ = fix_text(
+        """\
+        class A:
+            def __init__(self, x: int, y): ...
+        """
+    )
+    assert new_text == textwrap.dedent(
+        """\
+        class A:
+            def __init__(self, x: int, y) -> None: ...
+        """
+    )


### PR DESCRIPTION
This avoids issues in which an unannotated init is seen as a
completely unannotated method, and changes linter behavior.
It also enforces consistent style where there is otherwise
unnecessary developer variation.
