### PR TITLE
Add auto-fixing for IfExp of `is None` => `None`

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -8,6 +8,9 @@ Unreleased
 
 - Add support for Python 3.13
 - Remove support for Python 3.8
+- Add fixer behavior to convert variables to literal ``None`` when they are the
+  body of an if-expression which compares them with ``None``.
+  For example, ``None if x is None else foo(x)``.
 
 0.8.2
 -----

--- a/docs/fixer_rules.rst
+++ b/docs/fixer_rules.rst
@@ -87,6 +87,27 @@ After checking ``if x is None``, do not return ``x``.
     +    return None
 
 
+Prefer ``None`` as the Value of an If-Expression
+------------------------------------------------
+
+When using an if-expression, ``... if x is None else ...``, prefer ``None`` over ``x`` in the body.
+
+.. code-block:: diff
+
+    -x if x is None else ...
+    +None if x is None else ...
+
+This also applies to the ``is not`` case:
+
+.. code-block:: diff
+
+    -... if x is not None else x
+    +... if x is not None else None
+
+.. note::
+
+    Currently, ``slyp`` will not check for "yoda conditions", e.g., ``None is x``.
+
 Auto-concat Inline Strings
 --------------------------
 

--- a/src/slyp/driver.py
+++ b/src/slyp/driver.py
@@ -20,7 +20,7 @@ from slyp.hashable_file import HashableFile
 from slyp.result import Message, Result
 
 DEFAULT_DISABLED_CODES: set[str] = {"W201", "W202", "W203"}
-CONTRACT_VERSION: str = "1.6"
+CONTRACT_VERSION: str = "1.7"
 
 
 def driver_main(args: argparse.Namespace) -> bool:

--- a/src/slyp/fixer/transformer.py
+++ b/src/slyp/fixer/transformer.py
@@ -980,15 +980,64 @@ class SlypTransformer(libcst.CSTTransformer):
     def leave_IfExp(
         self, original_node: libcst.IfExp, updated_node: libcst.IfExp
     ) -> libcst.IfExp:
-        # parens are required for usage of the results:
+        new_node = updated_node
+
+        # parens are required for usage of the results, e.g.:
         #   (foo() if x else bar())["baz"]
-        if len(original_node.lpar) < 2:
-            return updated_node
-        return self.modify_parenthesized_node(
-            original_node,
-            updated_node,
-            preserve_innermost=True,
-        )
+        # so we preserve innermost
+        if len(original_node.lpar) >= 2:
+            new_node = self.modify_parenthesized_node(
+                original_node,
+                updated_node,
+                preserve_innermost=True,
+            )
+
+        # prefer `None` over a varname; convert expressions of the form
+        #     x if x is None else y
+        # to the form
+        #     None if x is None else y
+        if libcst.matchers.matches(
+            original_node.test,
+            libcst.matchers.Comparison(
+                left=libcst.matchers.Name(),
+                comparisons=[
+                    libcst.matchers.ComparisonTarget(
+                        operator=libcst.matchers.Is(),
+                        comparator=libcst.matchers.Name("None"),
+                    )
+                ],
+            ),
+        ):
+            var_name = original_node.test.left.value  # type: ignore[attr-defined]
+            if libcst.matchers.matches(
+                original_node.body, libcst.matchers.Name(var_name)
+            ):
+                new_node = new_node.with_changes(
+                    body=new_node.body.with_changes(value="None")
+                )
+        # same as above, but using `is not None`
+        # we won't worry about the "Yoda expression" spelling
+        elif libcst.matchers.matches(
+            original_node.test,
+            libcst.matchers.Comparison(
+                left=libcst.matchers.Name(),
+                comparisons=[
+                    libcst.matchers.ComparisonTarget(
+                        operator=libcst.matchers.IsNot(),
+                        comparator=libcst.matchers.Name("None"),
+                    )
+                ],
+            ),
+        ):
+            var_name = original_node.test.left.value  # type: ignore[attr-defined]
+            if libcst.matchers.matches(
+                original_node.orelse, libcst.matchers.Name(var_name)
+            ):
+                new_node = new_node.with_changes(
+                    orelse=new_node.orelse.with_changes(value="None")
+                )
+
+        return new_node
 
     def leave_Await(
         self, original_node: libcst.Await, updated_node: libcst.Await

--- a/tests/fixers/test_fix_ifexp_none_check.py
+++ b/tests/fixers/test_fix_ifexp_none_check.py
@@ -1,0 +1,19 @@
+import textwrap
+
+
+def test_none_checked_var_ifexp_transform(fix_text):
+    new_text, _ = fix_text("""\
+        x = var if var is None else f(var)
+        """)
+    assert new_text == textwrap.dedent("""\
+        x = None if var is None else f(var)
+        """)
+
+
+def test_none_checked_var_negated_ifexp_transform(fix_text):
+    new_text, _ = fix_text("""\
+        x = f(var) if var is not None else var
+        """)
+    assert new_text == textwrap.dedent("""\
+        x = f(var) if var is not None else None
+        """)


### PR DESCRIPTION
Like the return block autofix for none checks, an "if expression" which
checks a value against `None` should prefer to use `None` over the
variable name in its resultant sub-expression.
